### PR TITLE
Log4Net & Output true plugins

### DIFF
--- a/.build/Edi.targets
+++ b/.build/Edi.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+
+    <!-- Application directory -->
+    <ApplicationTargetDir Condition="$(ApplicationTargetDir) == '' Or $(ApplicationTargetDir) == '*Undefined*'">$(SolutionDir)$(Configuration)\</ApplicationTargetDir>
+
+    <!-- Plugins directory -->
+    <PluginsTargetDir Condition="$(PluginsTargetDir) == '' Or $(PluginsTargetDir) == '*Undefined*'">$(ApplicationTargetDir)Plugins\</PluginsTargetDir>
+
+    <!-- Determines if project is a plugin and it needs to be deployed to the solution application plugins folder -->
+    <DeployPlugin Condition=" '$(DeployPlugin)' == '' ">false</DeployPlugin>
+    
+    <!-- Determines if project is the main application and it needs to be deployed to the solution application folder -->
+    <DeployApplication Condition=" '$(DeployApplication)' == '' ">false</DeployApplication>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Deploy plugin -->
+    <BuildDependsOn Condition="$(DeployPlugin) == 'true'">
+      $(BuildDependsOn);
+      DeployPlugin;
+    </BuildDependsOn>
+
+    <!-- Deploy application -->
+    <BuildDependsOn Condition="$(DeployApplication) == 'true'">
+      $(BuildDependsOn);
+      DeployApplication;
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DeployPlugin">
+    <ItemGroup>
+      <PluginFiles Include="$(TargetDir)**\*.*"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginsTargetDir)$(TargetName)\%(RecursiveDir)"/>
+    <!-- <Message Text=" %(PluginFiles.Identity)" Importance="High"/> -->
+  </Target>
+
+  <Target Name="DeployApplication">
+    <ItemGroup>
+      <ApplicationFiles Include="$(TargetDir)**\*.*"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(ApplicationFiles)" DestinationFolder="$(ApplicationTargetDir)%(RecursiveDir)"/>
+    <!-- <Message Text=" %(ApplicationFiles.Identity)" Importance="High"/> -->
+  </Target>
+</Project>

--- a/Edi.sln
+++ b/Edi.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UML Application", "UML Application", "{C7A9E1F8-38FD-4268-BFC5-473CF16471D8}"
 EndProject
@@ -49,6 +49,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Edi.Themes", "Edi\Edi.Themes\Edi.Themes.csproj", "{69BC833C-0FE1-4288-BB80-BB457D07E638}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Settings", "Settings", "{31B14E7F-36E2-464A-A90A-64A07DEB02EB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{2A4570D1-7926-4ED0-9D06-C4005887577F}"
+	ProjectSection(SolutionItems) = preProject
+		.build\Edi.targets = .build\Edi.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -288,7 +293,7 @@ Global
 		{31B14E7F-36E2-464A-A90A-64A07DEB02EB} = {39FEC70F-8F35-4A04-B770-59F12A0CE83F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {132D3B9F-A6CB-49D9-B1E6-F122CCC2510E}
 		RESX_NeutralResourcesLanguage = en-US
+		SolutionGuid = {132D3B9F-A6CB-49D9-B1E6-F122CCC2510E}
 	EndGlobalSection
 EndGlobal

--- a/Edi/Edi.Themes/Edi.Themes.csproj
+++ b/Edi/Edi.Themes/Edi.Themes.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,7 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -47,7 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\x86\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\x86\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -58,7 +58,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\x86\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\x86\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -69,7 +69,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\x64\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\x64\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -80,7 +80,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vsFE48.tmp\x64\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Jason\AppData\Local\Temp\vsFAD1.tmp\x64\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FileListView">

--- a/Edi/Edi/Bootstapper.cs
+++ b/Edi/Edi/Bootstapper.cs
@@ -40,6 +40,15 @@ namespace Edi
         private readonly ISettingsManager mProgramSettingsManager = null;
         #endregion fields
 
+        /// <summary>
+        /// Initializes static members of the <see cref="Bootstapper"/> class.
+        /// This constructor will be called before MEF begins to take over.
+        /// </summary>
+        static Bootstapper()
+        {
+            System.IO.Directory.CreateDirectory(@".\Plugins");
+        }
+
         #region constructors
         public Bootstapper(App app,
                            StartupEventArgs eventArgs,
@@ -117,15 +126,8 @@ namespace Edi
 
             this.AggregateCatalog.Catalogs.Add(new AssemblyCatalog(typeof(AvalonDockLayoutViewModel).Assembly));
             this.AggregateCatalog.Catalogs.Add(new AssemblyCatalog(typeof(Bootstapper).Assembly));
-
-            //Scan directory for content
-////        string execPath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
-
-            DirectoryCatalog catalog = new DirectoryCatalog(".\\Plugins");
-            this.AggregateCatalog.Catalogs.Add(catalog);
-
-            catalog = new DirectoryCatalog(@"Plugins\UML");
-            this.AggregateCatalog.Catalogs.Add(catalog);
+            ////this.AggregateCatalog.Catalogs.Add(new PluginModuleCatalog(@".\Plugins"));
+            
         }
 
         protected override DependencyObject CreateShell()
@@ -144,7 +146,7 @@ namespace Edi
                 appVM.LoadConfigOnAppStartup(this.mOptions, this.mProgramSettingsManager, this.mThemes);
 
                 // Attempt to load a MiniUML plugin via the model class
-                MiniUML.Model.MiniUmlPluginLoader.LoadPlugins(appCore.AssemblyEntryLocation + @".\Plugins\UML\", this.AppViewModel);
+                //MiniUML.Model.MiniUmlPluginLoader.LoadPlugins(appCore.AssemblyEntryLocation + @".\Plugins\UML\", this.AppViewModel); // discover via Plugin folder instead
 
                 this.mMainWin = this.Container.GetExportedValue<MainWindow>();
 
@@ -228,7 +230,7 @@ namespace Edi
         protected override IModuleCatalog CreateModuleCatalog()
         {
             // Configure Prism ModuleCatalog via app.config configuration file
-            return new ConfigurationModuleCatalog();
+            return new PluginModuleCatalog(@".\Plugins", new ConfigurationModuleCatalog());
         }
 
         protected override void ConfigureContainer()

--- a/Edi/Edi/Edi.csproj
+++ b/Edi/Edi/Edi.csproj
@@ -18,6 +18,7 @@
     <WarningLevel>4</WarningLevel>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DeployApplication>true</DeployApplication>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -158,6 +159,7 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="Bootstapper.cs" />
+    <Compile Include="PluginModuleCatalog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -383,22 +385,28 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir).build\Edi.targets" />
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(SolutionDir)$(Configuration)\$(TargetFileName)</StartProgram>
+    <StartWorkingDirectory>$(SolutionDir)$(Configuration)</StartWorkingDirectory>
+  </PropertyGroup>
   <Target Name="AfterBuild">
     <ItemGroup>
       <!-- Specify locally dependent binaries -->
       <EdiProjectFiles Include="$(SolutionDir)02_Libs\00_bin\Xceed.Wpf.AvalonDock\Xceed.Wpf.AvalonDock.Themes.Expression.dll" />
       <EdiProjectFiles Include="$(SolutionDir)02_Libs\00_bin\Xceed.Wpf.AvalonDock\Xceed.Wpf.AvalonDock.Themes.Metro.dll" />
       <!-- Specify Plugin files -->
-      <EdiPluginUMLFiles Include="$(SolutionDir)MiniUML\Plugins\src\MiniUML.Plugins.UmlClassDiagram\$(OutDir)MiniUML.Plugins.UmlClassDiagram.dll" />
+      <!--<EdiPluginUMLFiles Include="$(SolutionDir)MiniUML\Plugins\src\MiniUML.Plugins.UmlClassDiagram\$(OutDir)MiniUML.Plugins.UmlClassDiagram.dll" />-->
       <!-- EdiPluginFiles Include="$(SolutionDir)Tools\BuiltIn\Files\$(OutDir)Files.dll" / -->
-      <EdiPluginFiles Include="$(SolutionDir)Tools\Log4NetTools\$(OutDir)Log4NetTools.dll" />
-      <EdiPluginFiles Include="$(SolutionDir)Edi\Edi.Documents\$(OutDir)Edi.Documents.dll" />
+      <!--<EdiPluginFiles Include="$(SolutionDir)Tools\Log4NetTools\$(OutDir)Log4NetTools.dll" />-->
+      <!--<EdiPluginFiles Include="$(SolutionDir)Edi\Edi.Documents\$(OutDir)Edi.Documents.dll" />-->
     </ItemGroup>
     <!-- Copy binaries not yet avalabile as nuget but as local binary only -->
     <Copy SourceFiles="@(EdiProjectFiles)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="false" />
     <!-- Copy binaries from build into their respective Plugins Folder (UML Plugins is seperate) -->
-    <Copy SourceFiles="@(EdiPluginUMLFiles)" DestinationFolder="$(ProjectDir)$(OutDir)\Plugins\UML\" SkipUnchangedFiles="false" />
-    <Copy SourceFiles="@(EdiPluginFiles)" DestinationFolder="$(ProjectDir)$(OutDir)\Plugins\" SkipUnchangedFiles="false" />
+    <!--<Copy SourceFiles="@(EdiPluginUMLFiles)" DestinationFolder="$(ProjectDir)$(OutDir)\Plugins\UML\" SkipUnchangedFiles="false" />-->
+    <!--<Copy SourceFiles="@(EdiPluginFiles)" DestinationFolder="$(ProjectDir)$(OutDir)\Plugins\" SkipUnchangedFiles="false" />-->
   </Target>
   <PropertyGroup>
     <!--

--- a/Edi/Edi/Edi.csproj.user
+++ b/Edi/Edi/Edi.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ProjectView>ProjectFiles</ProjectView>
-  </PropertyGroup>
-</Project>

--- a/Edi/Edi/PluginModuleCatalog.cs
+++ b/Edi/Edi/PluginModuleCatalog.cs
@@ -1,0 +1,288 @@
+﻿using Prism.Mef.Modularity;
+using Prism.Modularity;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Edi
+{
+    public class PluginModuleCatalog : ModuleCatalog
+    {
+        private readonly string pluginsDirectory = string.Empty;
+
+        private readonly IModuleCatalog fallbackCatalog;
+
+        public PluginModuleCatalog(string pluginsDirectory, IModuleCatalog fallbackCatalog)
+        {
+            if (Directory.Exists(pluginsDirectory))
+            {
+                this.pluginsDirectory = pluginsDirectory;
+            }
+
+            this.fallbackCatalog = fallbackCatalog;
+        }
+
+        private AppDomain CreateChildAppDomain(AppDomain parentDomain, string baseDirectory)
+        {
+            System.Security.Policy.Evidence evidence = new System.Security.Policy.Evidence(parentDomain.Evidence);
+
+            AppDomainSetup setupInformation = parentDomain.SetupInformation;
+            setupInformation.ApplicationBase = baseDirectory;
+
+            return AppDomain.CreateDomain("PluginModuleDiscovery", evidence, setupInformation);
+        }
+
+        private void ParseDirectory(string directory)
+        {
+            ////DirectoryInfo di = new DirectoryInfo(directory);
+            
+            string expandedDirectory = Path.GetFullPath(Environment.ExpandEnvironmentVariables(directory));
+            string fileName = Path.GetFileName(expandedDirectory);
+
+            string[] candidateAssemblyPaths = Directory.GetFiles(expandedDirectory, string.Format(CultureInfo.InvariantCulture, @"{0}.dll", fileName), SearchOption.TopDirectoryOnly);
+
+            if (candidateAssemblyPaths.Length > 0)
+            {
+                AppDomain childAppDomain = this.CreateChildAppDomain(AppDomain.CurrentDomain, expandedDirectory);
+                Type loaderType = typeof(InnerModuleInfoLoader);
+
+                try
+                {
+                    InnerModuleInfoLoader loader = (InnerModuleInfoLoader)childAppDomain.CreateInstanceFrom(loaderType.Assembly.Location, loaderType.FullName).Unwrap();
+                    this.Items.AddRange(loader.LoadModules(candidateAssemblyPaths));
+                }
+                catch (FileNotFoundException)
+                {
+                    // Continue loading assemblies even if an assembly can not be loaded in the new AppDomain
+                }
+                finally
+                {
+                    AppDomain.Unload(childAppDomain);
+                }
+            }
+
+            foreach (string d in Directory.GetDirectories(expandedDirectory))
+            {
+                this.ParseDirectory(d);
+            }
+        }
+
+        private Assembly ChildAppDomain_ReflectionOnlyAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            try
+            {
+                return Assembly.ReflectionOnlyLoad(args.Name);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public override void Initialize()
+        {
+            this.fallbackCatalog.Initialize();
+            base.Initialize();
+        }
+
+        /// <summary>
+        /// Drives the main logic of building the child domain and searching for the assemblies.
+        /// </summary>
+        protected override void InnerLoad()
+        {
+            if (this.fallbackCatalog != null)
+            {
+                foreach (ModuleInfo module in this.fallbackCatalog.Modules)
+                {
+                    this.Items.Add(module);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.pluginsDirectory))
+            {
+                try
+                {
+                    this.ParseDirectory(this.pluginsDirectory);
+                }
+                catch (Exception)
+                {
+                    // Fail silently
+                }
+            }
+        }
+
+        private class InnerModuleInfoLoader : MarshalByRefObject
+        {
+            private static Assembly OnReflectionOnlyResolve(ResolveEventArgs args)
+            {
+                Assembly loadedAssembly = AppDomain.CurrentDomain.ReflectionOnlyGetAssemblies().FirstOrDefault(
+                    asm => string.Equals(asm.FullName, args.Name, StringComparison.OrdinalIgnoreCase));
+                if (loadedAssembly != null)
+                {
+                    return loadedAssembly;
+                }
+
+                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+                UriBuilder uri = new UriBuilder(codeBase);
+                string path = Uri.UnescapeDataString(uri.Path);
+
+                DirectoryInfo directory = new DirectoryInfo(Path.GetDirectoryName(path));
+                if (directory != null)
+                {
+                    AssemblyName assemblyName = new AssemblyName(args.Name);
+                    string dependentAssemblyFilename = Path.Combine(directory.FullName, assemblyName.Name + ".dll");
+                    if (File.Exists(dependentAssemblyFilename))
+                    {
+                        return Assembly.ReflectionOnlyLoadFrom(dependentAssemblyFilename);
+                    }
+                }
+
+                return Assembly.ReflectionOnlyLoad(args.Name);
+            }
+
+            internal ModuleInfo[] LoadModules(string[] assemblies)
+            {
+                IList<ModuleInfo> moduleList = new List<ModuleInfo>();
+
+                ResolveEventHandler resolveEventHandler = delegate (object sender, ResolveEventArgs args) { return OnReflectionOnlyResolve(args); };
+
+                try
+                {
+                    AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += resolveEventHandler;
+
+                    Assembly moduleReflectionOnlyAssembly = Assembly.ReflectionOnlyLoad(typeof(ModuleExportAttribute).Assembly.FullName);
+
+                    Type ModuleExportAttributeType = moduleReflectionOnlyAssembly.GetType(typeof(ModuleExportAttribute).FullName);
+
+                    foreach (string assemblyPath in assemblies)
+                    {
+                        try
+                        {
+                            Assembly assembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
+                            Type[] assemblyTypes = assembly.GetTypes();
+
+                            foreach (Type type in assemblyTypes)
+                            {
+                                foreach (CustomAttributeData attributeData in type.GetCustomAttributesData())
+                                {
+                                    if (attributeData.AttributeType == ModuleExportAttributeType)
+                                    {
+                                        if (!type.IsAbstract)
+                                        {
+                                            moduleList.Add(CreateModuleInfo(type));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch (FileNotFoundException)
+                        {
+                            // Continue loading assemblies even if an assembly can not be loaded in the new AppDomain
+                        }
+                    }
+
+
+                }
+                catch (Exception)
+                {
+                    // Fail silently
+                }
+                finally
+                {
+                    AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= resolveEventHandler;
+                }
+
+                int modulesCount = moduleList.Count;
+                ModuleInfo[] modules = new ModuleInfo[modulesCount];
+
+                if (modulesCount > 0)
+                {
+                    moduleList.CopyTo(modules, 0);
+                }
+
+                return modules;
+            }
+
+            private static ModuleInfo CreateModuleInfo(Type type)
+            {
+                string moduleName = type.Name;
+                List<string> dependsOn = new List<string>();
+                bool onDemand = false;
+                var moduleAttribute = CustomAttributeData.GetCustomAttributes(type).FirstOrDefault(cad => cad.Constructor.DeclaringType.FullName == typeof(ModuleAttribute).FullName);
+
+                if (moduleAttribute != null)
+                {
+                    foreach (CustomAttributeNamedArgument argument in moduleAttribute.NamedArguments)
+                    {
+                        string argumentName = argument.MemberInfo.Name;
+                        switch (argumentName)
+                        {
+                            case "ModuleName":
+                                moduleName = (string)argument.TypedValue.Value;
+                                break;
+
+                            case "OnDemand":
+                                onDemand = (bool)argument.TypedValue.Value;
+                                break;
+
+                            case "StartupLoaded":
+                                onDemand = !((bool)argument.TypedValue.Value);
+                                break;
+                        }
+                    }
+                }
+
+                var moduleDependencyAttributes = CustomAttributeData.GetCustomAttributes(type).Where(cad => cad.Constructor.DeclaringType.FullName == typeof(ModuleDependencyAttribute).FullName);
+                foreach (CustomAttributeData cad in moduleDependencyAttributes)
+                {
+                    dependsOn.Add((string)cad.ConstructorArguments[0].Value);
+                }
+
+                ModuleInfo moduleInfo = new ModuleInfo(moduleName, type.AssemblyQualifiedName)
+                {
+                    InitializationMode =
+                        onDemand
+                            ? InitializationMode.OnDemand
+                            : InitializationMode.WhenAvailable,
+                    Ref = type.Assembly.CodeBase,
+                };
+                moduleInfo.DependsOn.AddRange(dependsOn);
+                return moduleInfo;
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Class that provides extension methods to Collection
+    /// </summary>
+    public static class CollectionExtensions
+    {
+        /// <summary>
+        /// Add a range of items to a collection.
+        /// </summary>
+        /// <typeparam name="T">Type of objects within the collection.</typeparam>
+        /// <param name="collection">The collection to add items to.</param>
+        /// <param name="items">The items to add to the collection.</param>
+        /// <returns>The collection.</returns>
+        /// <exception cref="System.ArgumentNullException">An <see cref="System.ArgumentNullException"/> is thrown if <paramref name="collection"/> or <paramref name="items"/> is <see langword="null"/>.</exception>
+        public static Collection<T> AddRange<T>(this Collection<T> collection, IEnumerable<T> items)
+        {
+            if (collection == null) throw new System.ArgumentNullException("collection");
+            if (items == null) throw new System.ArgumentNullException("items");
+
+            foreach (var each in items)
+            {
+                collection.Add(each);
+            }
+
+            return collection;
+        }
+    }
+}

--- a/Edi/Edi/app.config
+++ b/Edi/Edi/app.config
@@ -14,8 +14,8 @@
 
 		- module assemblyFile="Output.dll" moduleType="Output.Module" moduleName="MEFLoadOutputTools" startupLoaded="true" / Is initialized ín BootStrapper -->
     <module assemblyFile="Files.dll" moduleType="Files.Module" moduleName="MEFLoadFiles" startupLoaded="true" />
-    <!-- module assemblyFile="Edi.Documents.dll" moduleType="EdiDocuments.Module" moduleName="MEFLoadEdiDocuments" startupLoaded="true" / -->
-    <!-- module assemblyFile="Plugins/Log4NetTools.dll" moduleType="Log4NetTools.Module" moduleName="MEFLoadLog4NetTools" startupLoaded="true" / -->
+    <module assemblyFile="Edi.Documents.dll" moduleType="EdiDocuments.Module" moduleName="MEFLoadEdiDocuments" startupLoaded="true" />
+    <!--<module assemblyFile="Plugins\Log4NetTools\Log4NetTools.dll" moduleType="Log4NetTools.Module" moduleName="MEFLoadLog4NetTools" startupLoaded="true" />-->
   </modules>
 
 	<!--

--- a/MiniUML/MiniUML.Model/MiniUML.Model.csproj
+++ b/MiniUML/MiniUML.Model/MiniUML.Model.csproj
@@ -112,6 +112,7 @@
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/MiniUML/MiniUML.Model/MiniUmlPluginLoader.cs
+++ b/MiniUML/MiniUML.Model/MiniUmlPluginLoader.cs
@@ -7,15 +7,22 @@ namespace MiniUML.Model
     using MiniUML.Model.ViewModels.Document;
     using MsgBox;
     using Microsoft.Practices.ServiceLocation;
+    using System.ComponentModel.Composition;
+    using Prism.Mef.Modularity;
 
     /// <summary>
     /// This class load MiniUML Plug-Ins at run-time from the specified folder.
     /// </summary>
-    public static class MiniUmlPluginLoader
+    [ModuleExport(typeof(MiniUmlPluginLoader))]
+    public class MiniUmlPluginLoader
     {
-        #region methods
-        public static void LoadPlugins(string pluginDirectory,
+        [ImportingConstructor]
+        public MiniUmlPluginLoader(string pluginDirectory,
                                        IMiniUMLDocument windowViewModel)
+        
+        #region methods
+        //public static void LoadPlugins(string pluginDirectory,
+        //                               IMiniUMLDocument windowViewModel)
         {
             string[] assemblyFiles = { };
             var msgBox = ServiceLocator.Current.GetInstance<IMessageBoxService>();

--- a/MiniUML/Plugins/src/MiniUML.Plugins.UmlClassDiagram/MiniUML.Plugins.UmlClassDiagram.csproj
+++ b/MiniUML/Plugins/src/MiniUML.Plugins.UmlClassDiagram/MiniUML.Plugins.UmlClassDiagram.csproj
@@ -28,6 +28,9 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <DeployPlugin>true</DeployPlugin>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -91,14 +94,34 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationFramework.Aero">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="Prism, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Prism.Core.6.3.0\lib\net45\Prism.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Prism.Mef.Wpf, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Prism.Mef.6.3.0\lib\net45\Prism.Mef.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Prism.Wpf, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Prism.Wpf.6.3.0\lib\net45\Prism.Wpf.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Prism.Wpf.6.3.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -270,6 +293,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -355,6 +379,7 @@
     <Resource Include="Images\Shapes\Activity\EventToolbox.png" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir).build\Edi.targets" />
   <!-- Import Project="$(ProgramFiles)\MSBuild\StyleCop\v4.7\StyleCop.Targets" / -->
   <PropertyGroup>
     <PostBuildEvent>REM Copy /Y "$(TargetPath)" "$(SolutionDir)Edi\Edi\Plugins\UML"

--- a/MiniUML/Plugins/src/MiniUML.Plugins.UmlClassDiagram/packages.config
+++ b/MiniUML/Plugins/src/MiniUML.Plugins.UmlClassDiagram/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
+  <package id="Prism.Core" version="6.3.0" targetFramework="net451" />
+  <package id="Prism.Mef" version="6.3.0" targetFramework="net451" />
+  <package id="Prism.Wpf" version="6.3.0" targetFramework="net451" />
+</packages>

--- a/Tools/BuiltIn/Output/Module/MEFLoadOutputTools.cs
+++ b/Tools/BuiltIn/Output/Module/MEFLoadOutputTools.cs
@@ -33,6 +33,11 @@
         private readonly IMessageManager mMessageManager = null;
         #endregion fields
 
+        static MEFLoadOutputTools()
+        {
+            
+        }
+
         /// <summary>
         /// Class constructor
         /// </summary>

--- a/Tools/Log4NetTools/Log4NetTools.csproj
+++ b/Tools/Log4NetTools/Log4NetTools.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DeployPlugin>true</DeployPlugin>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -159,11 +160,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(SolutionDir).build\Edi.targets" />
 </Project>


### PR DESCRIPTION
Major revisions to csproj files which now handle dumping all respective
project files into their own folder.  Custom Edi.targets created to
handle file copy automation.  Edi.targets uses MSBuild macros for
robustness.

Log4Net & Output are now decorated with export attributes which are
picked up but the PluginModuleCatalog class.

PluginModuleCatalog is responsible for dynamically finding and loading
any assembly with types that have export attributes.

TODO:
Investigate if FIles.dll, Edi.Documents.dll can be converted to pure
plugin architecture.  They have multiple Edi dependencies so it may not
be possible without a major solution overhaul.