### PR TITLE
Code improvement - Edi Util 

### DIFF
--- a/Edi/Edi.Themes/Edi.Themes.csproj
+++ b/Edi/Edi.Themes/Edi.Themes.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,7 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -47,7 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\x86\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\x86\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -58,7 +58,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\x86\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\x86\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -69,7 +69,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\x64\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\x64\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -80,7 +80,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <IntermediateOutputPath>C:\Users\NOP\AppData\Local\Temp\vs8DB5.tmp\x64\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\Shreyas.SHREYAS\AppData\Local\Temp\vsA5A8.tmp\x64\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">

--- a/Edi/Edi.Util/ActivateWindow/WindowLister.cs
+++ b/Edi/Edi.Util/ActivateWindow/WindowLister.cs
@@ -35,12 +35,8 @@
 		public WindowInfo[] GetWindows(string processName = null)
 		{
 			List<WindowInfo> windows = new List<WindowInfo>();
-			Process[] allProcesses;
 
-			if (processName == null)
-				allProcesses = Process.GetProcesses();
-			else
-				allProcesses = Process.GetProcessesByName(processName);
+		    var allProcesses = processName == null ? Process.GetProcesses() : Process.GetProcessesByName(processName);
 
 			foreach (Process process in allProcesses)
 			{
@@ -75,7 +71,7 @@
 				return;
 			}
 
-			if (w != null && w.Length == 0)
+			if (w.Length == 0)
 			{
 				logger.Warn("--> Failed to activate Window (w is zero).");
 				return;

--- a/Edi/Edi.Util/Msg/Msg.cs
+++ b/Edi/Edi.Util/Msg/Msg.cs
@@ -13,8 +13,8 @@
 		/// </summary>
 		public Msg()
 		{
-			this.Message = string.Empty;
-			this.CategoryOfMsg = MsgCategory.Error;
+			Message = string.Empty;
+			CategoryOfMsg = MsgCategory.Error;
 		}
 
 		/// <summary>
@@ -25,8 +25,8 @@
 		public Msg(string strMsg, MsgCategory type = MsgCategory.Error)
 			: this()
 		{
-			this.Message = ((strMsg == null ? string.Empty : strMsg).Length == 0 ? Strings.STR_Category_Unknown_Internal_Error : strMsg);
-			this.CategoryOfMsg = type;
+			Message = ((strMsg ?? string.Empty).Length == 0 ? Strings.STR_Category_Unknown_Internal_Error : strMsg);
+			CategoryOfMsg = type;
 		}
 
 		/// <summary>
@@ -37,8 +37,8 @@
 		{
 			if (copyThis == null) return;
 
-			this.CategoryOfMsg = copyThis.CategoryOfMsg;
-			this.Message = copyThis.Message;
+			CategoryOfMsg = copyThis.CategoryOfMsg;
+			Message = copyThis.Message;
 		}
 		#endregion constructor
 
@@ -82,18 +82,18 @@
 		/// <summary>
 		/// Get property with a string representation that can be displayed to the user
 		/// </summary>
-		public string Message { get; private set; }
+		public string Message { get; }
 
 		/// <summary>
 		/// Get <seealso cref="MsgCategory"/> property to tag this message with a category.
 		/// </summary>
-		public MsgCategory CategoryOfMsg { get; private set; }
+		public MsgCategory CategoryOfMsg { get; }
 
 		public string MessageType
 		{
 			get
 			{
-				switch (this.CategoryOfMsg)
+				switch (CategoryOfMsg)
 				{
 					case MsgCategory.Information:
 						return Strings.STR_Category_Information;
@@ -107,8 +107,7 @@
 					case MsgCategory.InternalError:
 						return Strings.STR_Category_InternalError;
 
-					case MsgCategory.Unknown:
-					default:
+				    default:
 						return Strings.STR_Category_UnknownError;
 				}
 			}

--- a/Edi/Edi.Util/SingletonApplicationEnforcer.cs
+++ b/Edi/Edi.Util/SingletonApplicationEnforcer.cs
@@ -65,14 +65,8 @@
 		/// <value>The arg delimeter.</value>
 		public string ArgDelimeter
 		{
-			get
-			{
-				return argDelimiter;
-			}
-			set
-			{
-				argDelimiter = value;
-			}
+			get => argDelimiter;
+		    set => argDelimiter = value;
 		}
 
 		/// <summary>
@@ -85,21 +79,9 @@
 		public SingletonApplicationEnforcer(Action<IEnumerable<string>> processArgsFunc, Action<string> processArgsFunc1,
 																				string applicationId = "DisciplesRock")
 		{
-			if (processArgsFunc == null)
-			{
-				throw new ArgumentNullException("processArgsFunc");
-			}
+		    this.processArgsFunc = processArgsFunc ?? throw new ArgumentNullException(nameof(processArgsFunc));
 
-            if (processArgsFunc != null)
-            {
-                this.processArgsFunc = processArgsFunc;
-            }
-            else
-            {
-                throw new ArgumentNullException("processArgsFunc1");
-            }
-
-			this.processActivateFunc = processArgsFunc1;
+		    processActivateFunc = processArgsFunc1;
 			this.applicationId = applicationId;
 		}
 		#endregion properties
@@ -116,10 +98,8 @@
             string argsWaitHandleName = "ArgsWaitHandle_" + applicationId;
             string memoryFileName = "ArgFile_" + applicationId;
 
-            bool createdNew;
-
-            EventWaitHandle argsWaitHandle = new EventWaitHandle(
-				false, EventResetMode.AutoReset, argsWaitHandleName, out createdNew);
+		    EventWaitHandle argsWaitHandle = new EventWaitHandle(
+				false, EventResetMode.AutoReset, argsWaitHandleName, out var createdNew);
 
 			GC.KeepAlive(argsWaitHandle);
              
@@ -151,7 +131,7 @@
                                         logger.Error("Unable to retrieve string. ", ex);
                                         continue;
                                     }
-                                    string[] argsSplit = args.Split(new string[] { argDelimiter },
+                                    string[] argsSplit = args.Split(new[] { argDelimiter },
                                                                                                     StringSplitOptions.RemoveEmptyEntries);
                                     processArgsFunc(argsSplit);
                                 }

--- a/Edi/SimpleControls/Command/RelayCommand.cs
+++ b/Edi/SimpleControls/Command/RelayCommand.cs
@@ -37,10 +37,7 @@
 		/// <param name="canExecute">The execution status logic.</param>
 		public RelayCommand(Action<T> execute, Predicate<T> canExecute)
 		{
-			if (execute == null)
-				throw new ArgumentNullException(nameof(execute));
-
-			mExecute = execute;
+		    mExecute = execute ?? throw new ArgumentNullException(nameof(execute));
 			mCanExecute = canExecute;
 		}
 
@@ -130,10 +127,7 @@
 		/// <param name="canExecute">The execution status logic.</param>
 		public RelayCommand(Action execute, Func<bool> canExecute)
 		{
-			if (execute == null)
-				throw new ArgumentNullException(nameof(execute));
-
-			mExecute = execute;
+		    mExecute = execute ?? throw new ArgumentNullException(nameof(execute));
 			mCanExecute = canExecute;
 		}
 

--- a/Edi/SimpleControls/Command/RelayCommand.cs
+++ b/Edi/SimpleControls/Command/RelayCommand.cs
@@ -16,8 +16,8 @@
 	internal class RelayCommand<T> : ICommand
 	{
 		#region Fields
-		private readonly Action<T> mExecute = null;
-		private readonly Predicate<T> mCanExecute = null;
+		private readonly Action<T> mExecute;
+		private readonly Predicate<T> mCanExecute;
 		#endregion // Fields
 
 		#region Constructors
@@ -38,10 +38,10 @@
 		public RelayCommand(Action<T> execute, Predicate<T> canExecute)
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 
-			this.mExecute = execute;
-			this.mCanExecute = canExecute;
+			mExecute = execute;
+			mCanExecute = canExecute;
 		}
 
 		#endregion // Constructors
@@ -54,13 +54,13 @@
 		{
 			add
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested += value;
 			}
 
 			remove
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested -= value;
 			}
 		}
@@ -75,7 +75,7 @@
 		[DebuggerStepThrough]
 		public bool CanExecute(object parameter)
 		{
-			return this.mCanExecute == null ? true : this.mCanExecute((T)parameter);
+			return mCanExecute == null || mCanExecute((T)parameter);
 		}
 
 		/// <summary>
@@ -84,7 +84,7 @@
 		/// <param name="parameter"></param>
 		public void Execute(object parameter)
 		{
-			this.mExecute((T)parameter);
+			mExecute((T)parameter);
 		}
 		#endregion methods
 	}
@@ -131,10 +131,10 @@
 		public RelayCommand(Action execute, Func<bool> canExecute)
 		{
 			if (execute == null)
-				throw new ArgumentNullException("execute");
+				throw new ArgumentNullException(nameof(execute));
 
-			this.mExecute = execute;
-			this.mCanExecute = canExecute;
+			mExecute = execute;
+			mCanExecute = canExecute;
 		}
 
 		#endregion Constructors
@@ -147,13 +147,13 @@
 		{
 			add
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested += value;
 			}
 
 			remove
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested -= value;
 			}
 		}
@@ -169,7 +169,7 @@
 		[DebuggerStepThrough]
 		public bool CanExecute(object parameter)
 		{
-			return this.mCanExecute == null ? true : this.mCanExecute();
+			return mCanExecute == null || mCanExecute();
 		}
 
 		/// <summary>
@@ -178,7 +178,7 @@
 		/// <param name="parameter"></param>
 		public void Execute(object parameter)
 		{
-			this.mExecute();
+			mExecute();
 		}
 		#endregion Methods
 	}

--- a/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
+++ b/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
@@ -103,9 +103,7 @@ namespace SimpleControls.Hyperlink
 
             e.Handled = true;
 
-            WebHyperlink whLink = sender as WebHyperlink;
-
-            if (whLink == null) return;
+            if (!(sender is WebHyperlink whLink)) return;
 
             try
             {
@@ -131,9 +129,7 @@ namespace SimpleControls.Hyperlink
 
             e.Handled = true;
 
-            WebHyperlink whLink = sender as WebHyperlink;
-
-            if (whLink == null) return;
+            if (!(sender is WebHyperlink whLink)) return;
 
             try
             {

--- a/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
+++ b/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
@@ -12,7 +12,7 @@ namespace SimpleControls.Hyperlink
     /// <summary>
     /// Interaction logic for WebHyperlink.xaml
     /// </summary>
-    public partial class WebHyperlink : UserControl
+    public class WebHyperlink : UserControl
     {
         #region fields
         private static readonly DependencyProperty NavigateUriProperty =
@@ -33,38 +33,26 @@ namespace SimpleControls.Hyperlink
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WebHyperlink),
                       new FrameworkPropertyMetadata(typeof(WebHyperlink)));
 
-            WebHyperlink.mCopyUri = new RoutedCommand("CopyUri", typeof(WebHyperlink));
+            mCopyUri = new RoutedCommand("CopyUri", typeof(WebHyperlink));
 
             CommandManager.RegisterClassCommandBinding(typeof(WebHyperlink), new CommandBinding(mCopyUri, CopyHyperlinkUri));
             CommandManager.RegisterClassInputBinding(typeof(WebHyperlink), new InputBinding(mCopyUri, new KeyGesture(Key.C, ModifierKeys.Control, "Ctrl-C")));
 
-            WebHyperlink.mNavigateToUri = new RoutedCommand("NavigateToUri", typeof(WebHyperlink));
+            mNavigateToUri = new RoutedCommand("NavigateToUri", typeof(WebHyperlink));
             CommandManager.RegisterClassCommandBinding(typeof(WebHyperlink), new CommandBinding(mNavigateToUri, Hyperlink_CommandNavigateTo));
             ////CommandManager.RegisterClassInputBinding(typeof(WebHyperlink), new InputBinding(mCopyUri, new KeyGesture(Key.C, ModifierKeys.Control, "Ctrl-C")));
         }
 
         public WebHyperlink()
         {
-            this.mHypLink = null;
+            mHypLink = null;
         }
         #endregion constructor
 
         #region properties
-        public static RoutedCommand CopyUri
-        {
-            get
-            {
-                return WebHyperlink.mCopyUri;
-            }
-        }
+        public static RoutedCommand CopyUri => mCopyUri;
 
-        public static RoutedCommand NavigateToUri
-        {
-            get
-            {
-                return WebHyperlink.mNavigateToUri;
-            }
-        }
+        public static RoutedCommand NavigateToUri { get; } = mNavigateToUri;
 
         /// <summary>
         /// Declare NavigateUri property to allow a user who clicked
@@ -72,14 +60,14 @@ namespace SimpleControls.Hyperlink
         /// </summary>
         public System.Uri NavigateUri
         {
-            get { return (System.Uri)this.GetValue(WebHyperlink.NavigateUriProperty); }
-            set { this.SetValue(WebHyperlink.NavigateUriProperty, value); }
+            get => (System.Uri)GetValue(NavigateUriProperty);
+            set => SetValue(NavigateUriProperty, value);
         }
 
         public string Text
         {
-            get { return (string)this.GetValue(WebHyperlink.TextProperty); }
-            set { this.SetValue(WebHyperlink.TextProperty, value); }
+            get => (string) GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
         #endregion
 
@@ -88,18 +76,18 @@ namespace SimpleControls.Hyperlink
         {
             base.OnApplyTemplate();
 
-            this.mHypLink = this.GetTemplateChild("PART_Hyperlink") as System.Windows.Documents.Hyperlink;
-            Debug.Assert(this.mHypLink != null, "No Hyperlink in ControlTemplate!");
+            mHypLink = GetTemplateChild("PART_Hyperlink") as System.Windows.Documents.Hyperlink;
+            Debug.Assert(mHypLink != null, "No Hyperlink in ControlTemplate!");
 
             // Attach hyperlink event clicked event handler to Hyperlink ControlTemplate if there is no command defined
             // Commanding allows calling commands that are external to the control (application commands) with parameters
             // that can differ from whats available in this control (using converters and what not)
             //
             // Therefore, commanding overrules the Hyperlink.Clicked event when it is defined.
-            if (this.mHypLink != null)
+            if (mHypLink != null)
             {
-                if (this.mHypLink.Command == null)
-                    this.mHypLink.RequestNavigate += this.Hyperlink_RequestNavigate;
+                if (mHypLink.Command == null)
+                    mHypLink.RequestNavigate += Hyperlink_RequestNavigate;
             }
         }
 
@@ -149,11 +137,11 @@ namespace SimpleControls.Hyperlink
 
             try
             {
-                System.Windows.Clipboard.SetText(whLink.NavigateUri.AbsoluteUri);
+                Clipboard.SetText(whLink.NavigateUri.AbsoluteUri);
             }
             catch
             {
-                System.Windows.Clipboard.SetText(whLink.NavigateUri.OriginalString);
+                Clipboard.SetText(whLink.NavigateUri.OriginalString);
             }
         }
 


### PR DESCRIPTION
1. Used ternary operator instead of if and else block for simple condition.
2. Removed redundant `this `qualifier.
3. Converted auto-property to read only.
4. Removed one redundant case block.
5. Used expression body syntax.
6. Used `nameof `expression.
7. Removed one unreachable code .
8. Removed redundant type specification.
9. Used inline `out `variable declaration.