### PR TITLE
Code improvement

### DIFF
--- a/Edi/SimpleControls/Command/RelayCommand.cs
+++ b/Edi/SimpleControls/Command/RelayCommand.cs
@@ -127,10 +127,7 @@
 		/// <param name="canExecute">The execution status logic.</param>
 		public RelayCommand(Action execute, Func<bool> canExecute)
 		{
-			if (execute == null)
-				throw new ArgumentNullException("execute");
-
-			mExecute = execute;
+		    mExecute = execute ?? throw new ArgumentNullException(nameof(execute));
 			mCanExecute = canExecute;
 		}
 
@@ -177,6 +174,7 @@
 		{
 			mExecute();
 		}
+
 		#endregion Methods
 	}
 }

--- a/Edi/SimpleControls/Command/RelayCommand.cs
+++ b/Edi/SimpleControls/Command/RelayCommand.cs
@@ -16,8 +16,8 @@
 	internal class RelayCommand<T> : ICommand
 	{
 		#region Fields
-		private readonly Action<T> mExecute = null;
-		private readonly Predicate<T> mCanExecute = null;
+		private readonly Action<T> mExecute;
+		private readonly Predicate<T> mCanExecute;
 		#endregion // Fields
 
 		#region Constructors
@@ -37,11 +37,8 @@
 		/// <param name="canExecute">The execution status logic.</param>
 		public RelayCommand(Action<T> execute, Predicate<T> canExecute)
 		{
-			if (execute == null)
-				throw new ArgumentNullException("execute");
-
-			this.mExecute = execute;
-			this.mCanExecute = canExecute;
+		    mExecute = execute ?? throw new ArgumentNullException(nameof(execute));
+			mCanExecute = canExecute;
 		}
 
 		#endregion // Constructors
@@ -54,13 +51,13 @@
 		{
 			add
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested += value;
 			}
 
 			remove
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested -= value;
 			}
 		}
@@ -75,7 +72,7 @@
 		[DebuggerStepThrough]
 		public bool CanExecute(object parameter)
 		{
-			return this.mCanExecute == null ? true : this.mCanExecute((T)parameter);
+			return mCanExecute == null ? true : mCanExecute((T)parameter);
 		}
 
 		/// <summary>
@@ -84,7 +81,7 @@
 		/// <param name="parameter"></param>
 		public void Execute(object parameter)
 		{
-			this.mExecute((T)parameter);
+			mExecute((T)parameter);
 		}
 		#endregion methods
 	}
@@ -133,8 +130,8 @@
 			if (execute == null)
 				throw new ArgumentNullException("execute");
 
-			this.mExecute = execute;
-			this.mCanExecute = canExecute;
+			mExecute = execute;
+			mCanExecute = canExecute;
 		}
 
 		#endregion Constructors
@@ -147,13 +144,13 @@
 		{
 			add
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested += value;
 			}
 
 			remove
 			{
-				if (this.mCanExecute != null)
+				if (mCanExecute != null)
 					CommandManager.RequerySuggested -= value;
 			}
 		}
@@ -169,7 +166,7 @@
 		[DebuggerStepThrough]
 		public bool CanExecute(object parameter)
 		{
-			return this.mCanExecute == null ? true : this.mCanExecute();
+			return mCanExecute == null ? true : mCanExecute();
 		}
 
 		/// <summary>
@@ -178,7 +175,7 @@
 		/// <param name="parameter"></param>
 		public void Execute(object parameter)
 		{
-			this.mExecute();
+			mExecute();
 		}
 		#endregion Methods
 	}

--- a/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
+++ b/Edi/SimpleControls/Hyperlink/WebHyperlink.cs
@@ -12,7 +12,7 @@ namespace SimpleControls.Hyperlink
     /// <summary>
     /// Interaction logic for WebHyperlink.xaml
     /// </summary>
-    public partial class WebHyperlink : UserControl
+    public class WebHyperlink : UserControl
     {
         #region fields
         private static readonly DependencyProperty NavigateUriProperty =
@@ -33,38 +33,26 @@ namespace SimpleControls.Hyperlink
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WebHyperlink),
                       new FrameworkPropertyMetadata(typeof(WebHyperlink)));
 
-            WebHyperlink.mCopyUri = new RoutedCommand("CopyUri", typeof(WebHyperlink));
+            mCopyUri = new RoutedCommand("CopyUri", typeof(WebHyperlink));
 
             CommandManager.RegisterClassCommandBinding(typeof(WebHyperlink), new CommandBinding(mCopyUri, CopyHyperlinkUri));
             CommandManager.RegisterClassInputBinding(typeof(WebHyperlink), new InputBinding(mCopyUri, new KeyGesture(Key.C, ModifierKeys.Control, "Ctrl-C")));
 
-            WebHyperlink.mNavigateToUri = new RoutedCommand("NavigateToUri", typeof(WebHyperlink));
+            mNavigateToUri = new RoutedCommand("NavigateToUri", typeof(WebHyperlink));
             CommandManager.RegisterClassCommandBinding(typeof(WebHyperlink), new CommandBinding(mNavigateToUri, Hyperlink_CommandNavigateTo));
             ////CommandManager.RegisterClassInputBinding(typeof(WebHyperlink), new InputBinding(mCopyUri, new KeyGesture(Key.C, ModifierKeys.Control, "Ctrl-C")));
         }
 
         public WebHyperlink()
         {
-            this.mHypLink = null;
+            mHypLink = null;
         }
         #endregion constructor
 
         #region properties
-        public static RoutedCommand CopyUri
-        {
-            get
-            {
-                return WebHyperlink.mCopyUri;
-            }
-        }
+        public static RoutedCommand CopyUri => mCopyUri;
 
-        public static RoutedCommand NavigateToUri
-        {
-            get
-            {
-                return WebHyperlink.mNavigateToUri;
-            }
-        }
+        public static RoutedCommand NavigateToUri => mNavigateToUri;
 
         /// <summary>
         /// Declare NavigateUri property to allow a user who clicked
@@ -72,14 +60,14 @@ namespace SimpleControls.Hyperlink
         /// </summary>
         public System.Uri NavigateUri
         {
-            get { return (System.Uri)this.GetValue(WebHyperlink.NavigateUriProperty); }
-            set { this.SetValue(WebHyperlink.NavigateUriProperty, value); }
+            get => (System.Uri)GetValue(NavigateUriProperty);
+            set => SetValue(NavigateUriProperty, value);
         }
 
         public string Text
         {
-            get { return (string)this.GetValue(WebHyperlink.TextProperty); }
-            set { this.SetValue(WebHyperlink.TextProperty, value); }
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
         #endregion
 
@@ -88,18 +76,18 @@ namespace SimpleControls.Hyperlink
         {
             base.OnApplyTemplate();
 
-            this.mHypLink = this.GetTemplateChild("PART_Hyperlink") as System.Windows.Documents.Hyperlink;
-            Debug.Assert(this.mHypLink != null, "No Hyperlink in ControlTemplate!");
+            mHypLink = GetTemplateChild("PART_Hyperlink") as System.Windows.Documents.Hyperlink;
+            Debug.Assert(mHypLink != null, "No Hyperlink in ControlTemplate!");
 
             // Attach hyperlink event clicked event handler to Hyperlink ControlTemplate if there is no command defined
             // Commanding allows calling commands that are external to the control (application commands) with parameters
             // that can differ from whats available in this control (using converters and what not)
             //
             // Therefore, commanding overrules the Hyperlink.Clicked event when it is defined.
-            if (this.mHypLink != null)
+            if (mHypLink != null)
             {
-                if (this.mHypLink.Command == null)
-                    this.mHypLink.RequestNavigate += this.Hyperlink_RequestNavigate;
+                if (mHypLink.Command == null)
+                    mHypLink.RequestNavigate += Hyperlink_RequestNavigate;
             }
         }
 
@@ -115,9 +103,7 @@ namespace SimpleControls.Hyperlink
 
             e.Handled = true;
 
-            WebHyperlink whLink = sender as WebHyperlink;
-
-            if (whLink == null) return;
+            if (!(sender is WebHyperlink whLink)) return;
 
             try
             {
@@ -143,17 +129,15 @@ namespace SimpleControls.Hyperlink
 
             e.Handled = true;
 
-            WebHyperlink whLink = sender as WebHyperlink;
-
-            if (whLink == null) return;
+            if (!(sender is WebHyperlink whLink)) return;
 
             try
             {
-                System.Windows.Clipboard.SetText(whLink.NavigateUri.AbsoluteUri);
+                Clipboard.SetText(whLink.NavigateUri.AbsoluteUri);
             }
             catch
             {
-                System.Windows.Clipboard.SetText(whLink.NavigateUri.OriginalString);
+                Clipboard.SetText(whLink.NavigateUri.OriginalString);
             }
         }
 


### PR DESCRIPTION
1. Removed redundant field initializer.
2. Joined null with field initializer.
3. Used `nameof `expression.
4. Used null coalescing expression.
5. Removed redundant partial keyword.
6. Used expression bodied syntax.
7. Used pattern matching. 
