### PR TITLE
Updated MWindowInterfacesLib and MWindowLib to version 1.3.1.2

### DIFF
--- a/Edi/Edi.Apps/Edi.Apps.csproj
+++ b/Edi/Edi.Apps/Edi.Apps.csproj
@@ -92,10 +92,10 @@
     <Reference Include="MsgBox, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MsgBox.1.5.0\lib\net451\MsgBox.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowInterfacesLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowInterfacesLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowLib.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/Edi/Edi.Dialogs/Edi.Dialogs.csproj
+++ b/Edi/Edi.Dialogs/Edi.Dialogs.csproj
@@ -77,10 +77,10 @@
     <Reference Include="MsgBox, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MsgBox.1.5.0\lib\net451\MsgBox.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowInterfacesLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowInterfacesLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowLib.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/Edi/Edi.Themes/Edi.Themes.csproj
+++ b/Edi/Edi.Themes/Edi.Themes.csproj
@@ -107,10 +107,10 @@
     <Reference Include="MLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MLib.1.3.1.2\lib\net40\MLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowInterfacesLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowInterfacesLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowLib.dll</HintPath>
     </Reference>
     <Reference Include="NumericUpDownLib, Version=2.4.2.1, Culture=neutral, processorArchitecture=MSIL">

--- a/Edi/Settings/Edi.SettingsView/Edi.SettingsView.csproj
+++ b/Edi/Settings/Edi.SettingsView/Edi.SettingsView.csproj
@@ -73,10 +73,10 @@
     <Reference Include="MLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MLib.1.3.1.2\lib\net40\MLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowInterfacesLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowInterfacesLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowLib.dll</HintPath>
     </Reference>
     <Reference Include="NumericUpDownLib, Version=2.4.2.1, Culture=neutral, processorArchitecture=MSIL">

--- a/Tools/BuiltIn/Files/Files.csproj
+++ b/Tools/BuiltIn/Files/Files.csproj
@@ -114,10 +114,10 @@
     <Reference Include="MsgBox, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MsgBox.1.5.0\lib\net451\MsgBox.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowInterfacesLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowInterfacesLib.dll</HintPath>
     </Reference>
-    <Reference Include="MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MWindowLib, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Dirkster.MWindowLib.1.3.1.2\lib\net452\MWindowLib.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
First of all, thank you very much for your work on Edi, it is awesome!

When we clone the repository and build the solution, some errors appear because MWindowInterfacesLib and MWindowLib are not up to date in the projects that reference these packages (only the <Reference> not the <HintPath> in each .csproj):

 - "Could not locate the assembly "MWindowInterfacesLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL". Check to make sure the assembly exists on disk."

- "Could not locate the assembly "MWindowLib, Version=1.3.1.1, Culture=neutral, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. "

Therefore, I have updated these packages (which were also created by you 👍 ) if you are ok with that :)